### PR TITLE
fix: revoke and types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,8 @@ yarn-error.log*
 
 # local env files
 .env*.local
+.yarn
+.env
 
 # vercel
 .vercel

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/components/did-action-buttons.tsx
+++ b/components/did-action-buttons.tsx
@@ -2,8 +2,7 @@
 import { Button } from "./ui/button";
 import { registryFlow } from "@/workflows/registryFlow";
 
-export const DIDActionButtons = ({ id }: any) => {
-  console.log(id);
+export const DIDActionButtons = () => {
 
   return (
     <Button type="submit" onClick={registryFlow}>

--- a/examples/dock-credentials.ts
+++ b/examples/dock-credentials.ts
@@ -1,34 +1,5 @@
 import { apiPost } from "@/lib/actions/api-post";
-
-/**
- * An object containing credentials, with optional issuer.
- *
- * @param credential - The credential value.
- * @param issuer - An optional issuer of the credential.
- */
-type CredentialProps = {
-  credential: Credential;
-};
-
-export type Issuer = {
-    name: string;
-    image: string;
-    did: string;
-};
-
-export type Credential = {
-  id?: string;
-  type: string[];
-  subject: {
-    id?: string;
-    degree: {
-      type: string;
-      name: string;
-    };
-  };
-  issuanceDate: string;
-  expirationDate: string;
-};
+import type { Credential } from "@/types/dock";
 
 /**
  * Creates a credential with the provided credential data and issuer.
@@ -36,16 +7,16 @@ export type Credential = {
  * Wraps the credential in an object and sends an POST request to credentials/ to store it.
  * @returns A Promise that resolves to the credential data.
  */
-export async function createCredential({
-  credential
-}: CredentialProps): Promise<Credential> {
-  const wrapped = { credential };
+export async function createCredential(
+  credential: Credential
+): Promise<Credential> {
+  const wrapped = { credential: credential };
 
   return await apiPost({
-    relativeUrl: "credentials/", 
-    body: wrapped
+    relativeUrl: "credentials/",
+    body: wrapped,
   });
-};
+}
 
 /**
  * @name verifyCredential
@@ -56,9 +27,11 @@ export async function createCredential({
  */
 export async function verifyCredential({
   credential,
-}: CredentialProps): Promise<any> {
+}: {
+  credential: Credential;
+}): Promise<any> {
   return await apiPost({
-    relativeUrl: "verify/", 
-    body: credential
+    relativeUrl: "verify/",
+    body: credential,
   });
-};
+}

--- a/examples/dock-jobs.ts
+++ b/examples/dock-jobs.ts
@@ -1,23 +1,5 @@
 import { apiGet } from "@/lib/actions/api-get";
-
-export type Job = {
-  status: 'finalized' | 'todo' | 'in_progress';
-  id: string;
-  result: {
-    InBlock: string;
-  },
-};
-
-interface JobResult {
-  id: string;
-  status: 'finalized' | 'todo' | 'in_progress';
-  result: {
-    encodedTx: string;
-    finishQueryData: any[];
-    length: number;
-    userData: string;
-  };
-};
+import type { Job, JobResult } from "@/types/dock";
 
 /**
  * Gets a job by ID.
@@ -26,7 +8,7 @@ interface JobResult {
  */
 export async function getJob(id: string): Promise<JobResult> {
   const result = await apiGet({
-    relativeUrl: `jobs/${id}`, 
+    relativeUrl: `jobs/${id}`,
   });
 
   console.log("result in getJob:", result);
@@ -43,13 +25,14 @@ export async function waitForJobCompletion(jobId: string): Promise<void> {
   let job: JobResult = await getJob(jobId);
 
   if (!job) {
-    throw new Error('Job is undefined'); 
+    throw new Error("Job is undefined");
   }
 
-  while (job.status === "in_progress") {
-    await new Promise(resolve => setTimeout(resolve, 2000));
+  while (job.status !== "finalized") {
+    console.log(`waitForJobCompletion:while`, { status: job.status });
+    await new Promise((resolve) => setTimeout(resolve, 4000));
     job = await getJob(jobId);
   }
 
-  console.log(`Job Response: ${JSON.stringify(job)}`);
+  console.log(`Job Response`, { job });
 }

--- a/examples/dock-registries.ts
+++ b/examples/dock-registries.ts
@@ -1,48 +1,32 @@
 import { apiPost } from "@/lib/actions/api-post";
-import { Credential } from "./dock-credentials";
+import type { Credential } from "@/types/dock";
 
 
-export type CreateRegistryResponse = {
-  id: string;
-  data: {
-    id: string;
-    policy: {
-      type: string;
-      policy: string[];
-      addOnly: boolean;
-    };
-    type: string;
-  };
-};
+export async function getRegistry(id: string) {
+  
+}
 
-
-
-export async function createRegistry(
-  policyDid: string
-) {
-
+export async function createRegistry(policyDid: string) {
   const data = {
-    addOnly: true,
+    addOnly: false,
     policy: [policyDid],
   };
 
   try {
-    const response: CreateRegistryResponse = await apiPost({
-      relativeUrl: 'registries', 
-      body: data
+    const response: any = await apiPost({
+      relativeUrl: "registries",
+      body: data,
     });
-  
-    console.log("APIPOST response: ", response); 
+
+    console.log("APIPOST response: ", response);
 
     return response;
-    
   } catch (error) {
-    console.error(error); 
-  };
+    console.error(error);
+  }
 
   return undefined;
-};
-
+}
 
 /**
  * @name revoke
@@ -52,6 +36,8 @@ export async function createRegistry(
  * @param credential - The credential object containing the ID to revoke.
  */
 export async function revoke(registryId: string, credential: Credential) {
+  console.log("revoke:start:", { registryId, credential });
+
   const url = `registries/${registryId}`;
 
   const data = {
@@ -60,20 +46,19 @@ export async function revoke(registryId: string, credential: Credential) {
   };
   try {
     const response = await apiPost({
-      relativeUrl: url, 
-      body: data
+      relativeUrl: url,
+      body: data,
     });
-  
-    console.log("REVOKE APIPOST response: ", response); 
+
+    console.log("REVOKE APIPOST response: ", response);
 
     return response;
-
   } catch (error) {
-    console.error(error); 
-  };
+    console.error("revoke:error", error);
+  }
 
   return undefined;
-};
+}
 
 /**
  * @name unrevoke
@@ -90,5 +75,5 @@ export async function unrevoke(registryId: string, credential: { id: string }) {
     credentialIds: [credential.id],
   };
 
- /* return http.sendAndLog(() => http.post(url, data)); */
+  /* return http.sendAndLog(() => http.post(url, data)); */
 }

--- a/lib/actions/api-get.tsx
+++ b/lib/actions/api-get.tsx
@@ -3,7 +3,7 @@ const dock_api_key = process.env.NEXT_PUBLIC_DOCK_API_TOKEN as string;
 
 interface ApiGetParams {
   relativeUrl: string;
-  body?: any;
+  body?: object;
 }
 
 /**

--- a/types/dock.ts
+++ b/types/dock.ts
@@ -1,0 +1,60 @@
+// docs: https://docs.api.dock.io/#tocS_DIDDoc
+
+export type CreateRegistryResponse = {
+  id: string;
+  data: {
+    id: string;
+    policy: {
+      type: string;
+      policy: string[];
+      addOnly: boolean;
+    };
+    type: string;
+  };
+};
+
+export type JobStatus = "finalized" | "todo" | "in_progress";
+
+export type Job = {
+  id: string;
+  status: JobStatus;
+  result: {
+    inBlock: string;
+  };
+};
+
+export interface JobResult {
+  id: string;
+  status: JobStatus;
+  result: {
+    encodedTx: string;
+    finishQueryData: any[];
+    length: number;
+    userData: string;
+  };
+}
+
+export type Issuer = {
+  name: string;
+  image: string;
+  did: string;
+};
+
+export type DidDock = `did:dock:${string}`;
+
+type SubjectObject = { id: string } & Record<string, any>;
+/**
+ * This is a schema that represents a credential format expected by API caller when issuing a credential.
+ *
+ */
+export type Credential = {
+  id?: string;
+  context?: Array<string | object>;
+  type?: Array<string>;
+  subject: SubjectObject | Array<SubjectObject>;
+  schema?: string;
+  issuer?: DidDock;
+  issuanceDate?: string;
+  expirationDate?: string;
+  status?: object | string;
+};


### PR DESCRIPTION
# Added

- `types` folder and `dock` types.

# Fixed:

- `registryFlow` was missing the evocation registry  on `status` prop.

# Refactor

- Removed all types on `dock-credentials`, `dock-jobs` and `dock-registries`, can be found now on `types/dock`
- `api-get` body should be an object (if needed)